### PR TITLE
Fixed webkit scrolling bug

### DIFF
--- a/src/structio/intro.js
+++ b/src/structio/intro.js
@@ -49,7 +49,28 @@ bodylineheight;
 
 $(function(){
 	$body = $( 'body' );
-	bodylineheight = parseFloat( $body.css( 'line-height' ) );
+
+	// Calculate line height, bodylineheight, in pixels.
+	// The CSS value line-height can be:
+	//   1) a ratio (based on font-size),
+	//   2) a length (px/em/in/cm), or
+	//   3) the string "normal"
+
+	var heightstr = $body.css( 'line-height' ),
+		fontsizestr = $body.css('font-size');
+	// if line-height is a ratio (and therefore ends with a number), multiply it by the font size
+	if ( !isNaN( parseInt(heightstr[ heightstr.length-1 ]) ) ) {
+		bodylineheight = Math.floor( parseFloat( heightstr ) * parseFloat( fontsizestr ) );
+	}
+	// if line-height is "normal" (thus not a pixel value or ratio), guess the line height as 140% of the font size
+	else if( heightstr == "normal" ) {
+		bodylineheight = Math.floor( 1.4 * parseFloat( fontsizestr ) );
+	}
+	// else, line-height is a length value (we assume it is a px value)
+	// TODO: convert em/in/cm values to pixel
+	else {
+		bodylineheight = parseFloat( heightstr );
+	}
 });
 
 extend( $.cssHooks, {


### PR DESCRIPTION
As i mentioned on the Google Group discussion, WebKit provides the string "normal" instead of a pixel value for the line-height CSS property, so parseFloat returns NaN.  This breaks the scollTop call in structio/input.js.  My fix accepts "normal", a pixel value, or a ratio for line-height.  Note that I'm just making a guess of 140% of font-size for "normal", but it seem to work okay.  You may revise the guess if you like, but there's no "good" way to get the actual ratio or pixel value unless it's explicitly set in the CSS.

For this commit, I did not rebuild the minified files, because I'm sending you another pull request shortly, and I don't know which ones you'll accept (so I won't rebuild incompatible binaries for each separate pull request).
