### PR TITLE
Backslash escaping

### DIFF
--- a/src/ifvms.js/src/zvm/text.js
+++ b/src/ifvms.js/src/zvm/text.js
@@ -117,6 +117,7 @@ Text = Object.subClass({
 			table[i] = String.fromCharCode( i );
 			reverse[i] = i++;
 		}
+		table[ 92 ] = '\\\\'; // escape backslashes
 		this.unicode_table = table;
 		this.reverse_unicode_table = reverse;
 	},


### PR DESCRIPTION
This is a fix to a bug in zvm that causes any backslashes in the story output to be considered as escape characters. `\n` produces a newline, `\\` shows only one backslash etc. `\'` crashes Parchment completely. See http://iplayif.com/?story=https://dl.dropbox.com/u/27567916/test.z8 for a test case.
