### PR TITLE
Update parchment.css

### DIFF
--- a/src/parchment/parchment.css
+++ b/src/parchment/parchment.css
@@ -11,7 +11,7 @@ https://github.com/curiousdannii/parchment
 
 html
 {
-	overflow-y: scroll;
+	overflow-y: auto;
 	-webkit-text-size-adjust: none;
 }
 


### PR DESCRIPTION
Let the scrollability be decided automatically.

Was there any particular reason for always forcing the scrollbar to be shown?