### PR TITLE
More accurate file format detection

### DIFF
--- a/src/common/formats.js
+++ b/src/common/formats.js
@@ -33,7 +33,7 @@ async function generic_emglken_vm(options, requires)
 const formats = [
     {
         id: 'hugo',
-        extensions: /hex/,
+        extensions: /\.hex/,
         engines: [
             {
                 id: 'hugo',
@@ -45,7 +45,7 @@ const formats = [
 
     {
         id: 'glulx',
-        extensions: /gblorb|ulx/,
+        extensions: /\.(gblorb|ulx)/,
         engines: [
             {
                 id: 'quixe',
@@ -90,7 +90,7 @@ const formats = [
 
     {
         id: 'tads',
-        extensions: /gam|t3/,
+        extensions: /\.(gam|t3)/,
         engines: [
             {
                 id: 'tads',
@@ -102,7 +102,7 @@ const formats = [
 
     {
         id: 'zcode',
-        extensions: /zblorb|z3|z4|z5|z8/,
+        extensions: /\.(zblorb|z3|z4|z5|z8)/,
         engines: [
             {
                 id: 'zvm',

--- a/src/inform7/index.js
+++ b/src/inform7/index.js
@@ -42,11 +42,11 @@ function launch()
     // Discriminate
     const storyfilepath = options.default_story[0]
     let format
-    if (/zblorb|z3|z4|z5|z8/.test(storyfilepath))
+    if (/\.(zblorb|z3|z4|z5|z8)(\.js)?$/.test(storyfilepath))
     {
         format = 'zcode'
     }
-    else if (/gblorb|ulx/.test(storyfilepath))
+    else if (/\.(gblorb|ulx)(\.js)?$/.test(storyfilepath))
     {
         format = 'glulx'
     }


### PR DESCRIPTION
Checking that the file extension exists anywhere in the filename will easily lead to choosing the wrong format, especially .gam (game.z8 is categorized as a TADS file.) Added `.` in front of all extensions and changed the I7 template to check the end of the file as Inform generates always the same extensions.