### PR TITLE
Depend on emglken as an npm module. Fixes #77

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "src/upstream/quixe"]
 	path = src/upstream/quixe
 	url = git@github.com:curiousdannii/quixe.git
-[submodule "src/upstream/emglken"]
-	path = src/upstream/emglken
-	url = https://github.com/curiousdannii/emglken.git

--- a/gulpfile.esm.js
+++ b/gulpfile.esm.js
@@ -53,9 +53,9 @@ function js(opt)
                 plugins: [
                     alias({
                         entries: [
-                            { find: 'crypto', replacement: '../../../common/dummy-node.js' },
-                            { find: 'fs', replacement: '../../../common/dummy-node.js' },
-                            { find: 'path', replacement: '../../../common/dummy-node.js' },
+                            { find: 'crypto', replacement: '../../../src/common/dummy-node.js' },
+                            { find: 'fs', replacement: '../../../src/common/dummy-node.js' },
+                            { find: 'path', replacement: '../../../src/common/dummy-node.js' },
                         ]
                     }),
                     commonjs(),
@@ -73,7 +73,7 @@ function js(opt)
 const buildweb = gulp.parallel(
     copy({
         dest: 'dist/web/',
-        src: './src/upstream/emglken/build/*-core.wasm',
+        src: './node_modules/emglken/build/*-core.wasm',
         target: 'web',
     }),
     css({
@@ -85,13 +85,13 @@ const buildweb = gulp.parallel(
     ...js({
         dest: 'dist/web/',
         files: [
-            ['git', './src/upstream/emglken/src/git.js'],
-            ['glulxe', './src/upstream/emglken/src/glulxe.js'],
-            ['hugo', './src/upstream/emglken/src/hugo.js'],
+            ['git', './node_modules/emglken/src/git.js'],
+            ['glulxe', './node_modules/emglken/src/glulxe.js'],
+            ['hugo', './node_modules/emglken/src/hugo.js'],
             ['ie', './src/common/ie.js'],
             ['main', './src/common/launcher.js'],
             ['quixe', './src/common/quixe.js'],
-            ['tads', './src/upstream/emglken/src/tads.js'],
+            ['tads', './node_modules/emglken/src/tads.js'],
             ['zvm', './src/common/zvm.js'],
         ],
         format: 'es',

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@rollup/plugin-alias": "^3.1.1",
     "@rollup/stream": "git+https://github.com/andremacola/stream.git",
+    "emglken": "^0.3.3",
     "esm": "^3.2.25",
     "gulp": "^4.0.2",
     "gulp-clean-css": "^4.3.0",


### PR DESCRIPTION
This makes it wayyy easier to build and run Parchment. (You can `npm link` to do local development on emglken with Parchment.)