### PR TITLE
Backport CSS to hide mobile input placeholder when the input is focused

### DIFF
--- a/src/common/glkote.css
+++ b/src/common/glkote.css
@@ -165,6 +165,11 @@
   font-weight: bold;
 }
 
+input:focus::placeholder {
+  /* Hide "Tap here to type" placeholder when the input is focused */
+  color: transparent;
+}
+
 .BufferWindow .Input {
   font-family: var(--glkote-prop-family);
   font-size: 15px;


### PR DESCRIPTION
Backported from https://github.com/curiousdannii/glkote/commit/8df8ffa974a26fd300ce3bf8c0563971439154c2