### PR TITLE
Generate single-file HTML for a single story file

### DIFF
--- a/src/common/file.ts
+++ b/src/common/file.ts
@@ -21,7 +21,7 @@ export async function fetch_storyfile(options: ParchmentOptions, url: string) {
     let response: Response
 
     // Only directly access files same origin files or those from the list of reliable domains
-    let direct_access = same_domain
+    let direct_access = same_domain || story_url.protocol === 'data:'
     if (!direct_access) {
         for (const domain of options.direct_domains) {
             if (story_domain.endsWith(domain)) {

--- a/src/common/launcher.js
+++ b/src/common/launcher.js
@@ -73,7 +73,7 @@ class ParchmentLauncher
                 return
             }
 
-            this.load(storyfile_path)
+            this.load(storyfile_path, this.options.format)
         }
         catch (err) {
             this.options.GlkOte.error(err)

--- a/src/common/options.ts
+++ b/src/common/options.ts
@@ -25,6 +25,8 @@ export interface ParchmentOptions extends Partial<GlkOteOptions> {
     default_story?: [string],
     /** Domains to access directly: should always have both Access-Control-Allow-Origin and compression headers */
     direct_domains: string[],
+    /** Format ID, matching formats.js */
+    format?: string,
     /** Path to resources */
     lib_path: string,
     /** URL of Proxy */

--- a/src/tools/single-file.js
+++ b/src/tools/single-file.js
@@ -28,7 +28,14 @@ async function Uint8Array_to_base64(data) {
 export async function generate(options, files) {
     const inclusions = []
     if (options.single_file) {
-        inclusions.push('<script>parchment_options = {single_file: 1}</script>')
+        const parchment_options = {single_file: 1};
+        if (options.format) {
+            parchment_options.format = options.format;
+        }
+        if (options.story_file) {
+            parchment_options.story = `data:application/octet-stream;base64,` + await Uint8Array_to_base64(options.story_file)
+        }
+        inclusions.push(`<script>parchment_options = ${JSON.stringify(parchment_options, null, 2)}</script>`)
     }
 
     // Process the files

--- a/tools/make-single-file.js
+++ b/tools/make-single-file.js
@@ -17,6 +17,7 @@ import {fileURLToPath} from 'url'
 import util from 'util'
 
 import {generate} from '../src/tools/single-file.js'
+import Blorb from '../src/upstream/asyncglk/dist/blorb/blorb.js'
 
 const execFile = util.promisify(child_process.execFile)
 
@@ -93,7 +94,22 @@ if (story_file_path) {
         throw new Error(`Unknown storyfile format ${story_file_path}`)
     }
     if (format === 'blorb') {
-        throw new Error(`Bug! TODO implement blorb support ${story_file_path}`)
+        // fake jQuery, just enough to get the Blorb constructor to run
+        globalThis.$ = () => ({
+            html: () => ({
+                find: () => ({
+                    children: () => []
+                })
+            })
+        })
+        const blorb = new Blorb(options.story_file)
+        const blorb_chunks = {
+            GLUL: 'glulx',
+            ZCOD: 'zcode',
+        }
+        const chunktype = blorb.get_chunk('exec', 0)?.blorbtype
+        format = blorb_chunks[chunktype]
+        if (!format) throw new Error('Unknown storyfile format in Blorb')
     }
     options.terps = [formats[format].engine]
     options.format = format


### PR DESCRIPTION
Now you can run `node tools/make-single-file.js --story_file ~/intfiction/LostPig.z8`.

It will compute the format for the file based on file extension, then generate a `parchment.html` file with only the required terp and with the storyfile embedded in the HTML as a `data:` URI.

There is some funny business here around the format detection. In my initial implementation, I tried importing `formats.js` directly, but that includes `import Glk from '../upstream/glkote/glkapi.js'` which fails in Node because `glkapi.js` is ESM, but its `package.json` doesn't declare ESM. I've filed a separate PR https://github.com/curiousdannii/glkote/pull/11 against this.