### PR TITLE
Optimistically fetch files with CORS, falling back to proxy

### DIFF
--- a/src/common/options.ts
+++ b/src/common/options.ts
@@ -33,8 +33,6 @@ export interface ParchmentOptions extends Partial<GlkOteOptions> {
     auto_launch?: ParchmentTruthy,
     /** Story path in the array format traditionally used by Parchment for Inform 7 */
     default_story?: [string],
-    /** Domains to access directly: should always have both Access-Control-Allow-Origin and compression headers */
-    direct_domains: string[],
     /** Path to resources */
     lib_path: string,
     /** URL of Proxy */
@@ -71,9 +69,6 @@ export function get_default_options(): ParchmentOptions {
     return {
         auto_launch: 1,
         Dialog: WebDialog,
-        direct_domains: [
-            'unbox.ifarchive.org',
-        ],
         do_vm_autosave: 1,
         Glk: GlkOte_GlkApi,
         GlkOte: new WebGlkOte(),


### PR DESCRIPTION
Apropos #149 

> 1. IF Archive has CORS headers; there's no need to use the proxy in this case. We could whitelist some domains and list them as not requiring a proxy.
> 2. Instead of (or as well as) whitelisting, on the client-side, we could optimistically try to fetch a files directly; fall back to the proxy only if the fetch request fails.
> 3. Update the `Cache-Control` header to use `stale-while-revalidate` https://web.dev/articles/stale-while-revalidate perhaps something like: `Cache-Control: max-age=60, stale-while-revalidate=604800`.
>     Unfortunately, Cloudflare doesn't support `stale-while-revalidate` yet; [they say it's coming later this year](https://blog.cloudflare.com/browser-rendering-api-ga-rolling-out-cloudflare-snippets-swr-and-bringing-workers-for-platforms-to-our-paygo-plans).

This implements option 2.

I see that the code did have a way to whitelist domains, and so we _could_ have just whitelisted ifarchive.org, but, hey, there's no way of knowing what _other_ domains might well have CORS headers, so I figured we might as well just optimistically try to make the CORS request in all cases.