### PR TITLE
Add IF Archive and subdomains to direct domains list

### DIFF
--- a/src/common/options.ts
+++ b/src/common/options.ts
@@ -72,7 +72,10 @@ export function get_default_options(): ParchmentOptions {
         auto_launch: 1,
         Dialog: WebDialog,
         direct_domains: [
+            'ifarchive.org',
+            'mirror.ifarchive.org',
             'unbox.ifarchive.org',
+            'www.ifarchive.org',
         ],
         do_vm_autosave: 1,
         Glk: GlkOte_GlkApi,


### PR DESCRIPTION
Apropos #149 

> 1. IF Archive has CORS headers; there's no need to use the proxy in this case. We could whitelist some domains and list them as not requiring a proxy.
> 2. Instead of (or as well as) whitelisting, on the client-side, we could optimistically try to fetch a files directly; fall back to the proxy only if the fetch request fails.
> 3. Update the `Cache-Control` header to use `stale-while-revalidate` https://web.dev/articles/stale-while-revalidate perhaps something like: `Cache-Control: max-age=60, stale-while-revalidate=604800`.
>     Unfortunately, Cloudflare doesn't support `stale-while-revalidate` yet; [they say it's coming later this year](https://blog.cloudflare.com/browser-rendering-api-ga-rolling-out-cloudflare-snippets-swr-and-bringing-workers-for-platforms-to-our-paygo-plans).

This implements option 1, but I'm not sure we should do it this way; perhaps we should do option 2 instead, in PR #150.