### PR TITLE
Rewrite http: IF Archive URLs to https:

### DIFF
--- a/src/common/file.ts
+++ b/src/common/file.ts
@@ -33,9 +33,11 @@ export async function fetch_storyfile(options: ParchmentOptions, url: string, pr
 
     // Only directly access files same origin files or those from the list of reliable domains
     let direct_access = (same_protocol && same_domain) || story_url.protocol === 'data:'
-    if (!direct_access && same_protocol) {
+    if (!direct_access) {
         for (const domain of options.direct_domains) {
             if (story_domain.endsWith(domain)) {
+                // all direct domains require HTTPS
+                story_url.protocol = 'https:'
                 direct_access = true
                 break
             }


### PR DESCRIPTION
Apropos #149 and #153, in 20aca50f900d7eee5578ef08bac18b4b68b3c5ae we updated the code to use the proxy for links to `http://ifarchive.org`.

But for all of the valid direct domains, they all support/require HTTPS, so rather than proxying them and requesting them over HTTP, (and thereby caching them for a week), we should just rewrite those URLs to request them directly via CORS.