### PR TITLE
Fix build

### DIFF
--- a/src/common/launcher.ts
+++ b/src/common/launcher.ts
@@ -14,7 +14,7 @@ import '../web/web.css'
 import Cookies from 'js-cookie'
 
 import {/*AsyncGlk,*/ Blorb, fetch_resource, FileView, type ProgressCallback} from '../upstream/asyncglk/src/index-browser.js'
-import emglken_file_sizes from '../upstream/emglken/build/file-sizes.json'
+import emglken_file_sizes from 'emglken/build/file-sizes.json'
 
 import {find_format, identify_blorb_storyfile_format} from './formats.js'
 import type {ParchmentOptions, StoryOptions} from './interface.js'


### PR DESCRIPTION
This fixes the build out of the box, but the default build still has the warning: "⚠ Warning: Using npm rather than upstream version of Emglken" 

I'm not sure how I'm "supposed" to make that warning go away, but I deleted `node_modules/emglken` and replaced it with a symlink to `../src/upstream/emglken`. I then manually did a build in `src/upstream/emglken` with `build.sh`.

That symlink trickery made the warning go away, and the build still worked, so I think this PR should be safe to merge in both cases.