### PR TITLE
Fix Inform 7 template: sound support, gameport wrapper, options bug

### DIFF
--- a/build.js
+++ b/build.js
@@ -68,6 +68,7 @@ if (projects.includes('ifcomp')) {
 if (projects.includes('inform7')) {
     projects_to_build.push({
         entryPoints: {
+            glkaudio_bg: 'node_modules/glkaudio/glkaudio_bg.wasm',
             ie: 'src/common/ie.js',
             parchment: 'src/inform7/index.ts',
             waiting: 'src/common/waiting.gif',

--- a/src/inform7/index.ts
+++ b/src/inform7/index.ts
@@ -37,7 +37,7 @@ async function launch() {
     }
 
     // Update the Dialog storage version
-    await options.Dialog.init(this.options)
+    await options.Dialog.init(options)
 
     // Discriminate
     const storyfilepath = options.default_story[0]

--- a/src/inform7/manifest.txt
+++ b/src/inform7/manifest.txt
@@ -62,16 +62,18 @@ gz
 ! or gadget actually appears.
 
 [INTERPRETERBODY]
-        <div id="windowport">
-            <noscript>
-                <p>You'll need to turn on Javascript in your web browser to play this game.</p>
-            </noscript>
+        <div id="gameport">
+            <div id="windowport">
+                <noscript>
+                    <p>You'll need to turn on Javascript in your web browser to play this game.</p>
+                </noscript>
+            </div>
+            <div id="loadingpane">
+                <img src="interpreter/waiting.gif" alt="LOADING"><br>
+                <em>&nbsp;&nbsp;&nbsp;Loading...</em>
+            </div>
+            <div id="errorpane" style="display:none;"><div id="errorcontent">...</div></div>
         </div>
-        <div id="loadingpane">
-            <img src="interpreter/waiting.gif" alt="LOADING"><br>
-            <em>&nbsp;&nbsp;&nbsp;Loading...</em>
-        </div>
-        <div id="errorpane" style="display:none;"><div id="errorcontent">...</div></div>
 []
 
 ! The following footnote is added to the small print about how to play IF
@@ -103,6 +105,7 @@ processBase64Zcode('
 ! release is made. Anything not listed here won't be copied.
 
 bocfel.js
+glkaudio_bg.wasm
 glulxe.js
 ie.js
 jquery.min.js


### PR DESCRIPTION
## Summary

Three fixes for the Inform 7 release template that are needed to get sound working in released games:

- **Include `glkaudio_bg.wasm` in the build and manifest** — The WASM audio decoder was missing from both the esbuild `entryPoints` (build.js) and the manifest file list (manifest.txt). Without it, the Safari fallback decoder for Ogg Vorbis is unavailable in released games.

- **Add `#gameport` wrapper div to `[INTERPRETERBODY]`** — GlkOte's `ResizeObserver` expects `#windowport` to be inside a `#gameport` container. Without this wrapper, games released with the template hang on the loading spinner with a `parameter 1 is not of type 'Element'` error.

- **Fix `this.options` → `options` in index.ts** — The `launch()` function references `this.options` but `this` is not bound to the options object in that context. Should use the local `options` variable.

## Testing

Tested with a Glulx game compiled to `.gblorb` with 25 embedded Ogg Vorbis sound resources (ambient loops + one-shot sound effects), using the Inform 7 template built from this branch. Tested with: https://johnesco.github.io/zork1-sound-test/play.html

| Platform | Browser | Result |
|----------|---------|--------|
| Windows 11 | Chrome | Works — all sounds play |
| Windows 11 | Firefox | Works — all sounds play |
| Windows 11 | Edge | Works — all sounds play |
| Android | Chrome | Works — all sounds play |

🤖 Generated with [Claude Code](https://claude.com/claude-code)